### PR TITLE
feat: update build workflow to match all release branches and increase window size for better usability

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -3,7 +3,8 @@ name: 'build and publish'
 on:
   push:
     branches:
-      - release
+      - 'release/**' # Matches release/v1.0, release/v1.1, etc.
+      - 'release' # Also matches the exact "release" branch
   workflow_dispatch:
     inputs:
       version:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "RotMG Stash",
-        "width": 1280,
-        "height": 720,
+        "width": 1600,
+        "height": 900,
         "zoomHotkeysEnabled": true,
         "center": true
       }


### PR DESCRIPTION
This pull request includes updates to the build and publish workflow and changes to the application window configuration.

Workflow updates:
* [`.github/workflows/build-and-publish.yml`](diffhunk://#diff-c58efb7d239ba7eb89123ff4b9e3117bd84c382787283c3f149cf0c4620d7029L6-R7): Expanded the branches to match patterns like `release/**` and the exact `release` branch.

Application configuration updates:
* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L16-R17): Updated the application window dimensions from 1280x720 to 1600x900.