### PR TITLE
feat: modify device token output to remove newline characters

### DIFF
--- a/scripts/get-device-token.ps1
+++ b/scripts/get-device-token.ps1
@@ -25,13 +25,10 @@ if ([string]::IsNullOrEmpty($hardwareInfo)) {
     exit 1
 }
 
-# Log out the raw hardware info
-Write-Output "Hardware Info: $hardwareInfo"
-
-# Compute the SHA1 hash of the concatenated hardware info.
 $sha1 = [System.Security.Cryptography.SHA1]::Create()
 $bytes = [System.Text.Encoding]::UTF8.GetBytes($hardwareInfo)
 $hashBytes = $sha1.ComputeHash($bytes)
-$hashString = -join ($hashBytes | ForEach-Object { $_.ToString("x2") })
+$deviceToken = -join ($hashBytes | ForEach-Object { $_.ToString("x2") })
 
-Write-Output $hashString
+# Output the device token without the \r\n
+Write-Host -NoNewline $deviceToken

--- a/src-tauri/src/devicetoken_script.rs
+++ b/src-tauri/src/devicetoken_script.rs
@@ -29,5 +29,6 @@ $bytes = [System.Text.Encoding]::UTF8.GetBytes($hardwareInfo)
 $hashBytes = $sha1.ComputeHash($bytes)
 $deviceToken = -join ($hashBytes | ForEach-Object { $_.ToString("x2") })
 
-Write-Output $deviceToken
+# Output the device token without the \r\n
+Write-Host -NoNewline $deviceToken
 "#;

--- a/src/components/Settings/Experimental/device-token-powershell-script.ts
+++ b/src/components/Settings/Experimental/device-token-powershell-script.ts
@@ -27,4 +27,5 @@ $bytes = [System.Text.Encoding]::UTF8.GetBytes($hardwareInfo)
 $hashBytes = $sha1.ComputeHash($bytes)
 $deviceToken = -join ($hashBytes | ForEach-Object { $_.ToString("x2") })
 
-Write-Output $deviceToken`;
+# Output the device token without the \r\n
+Write-Host -NoNewline $deviceToken`;


### PR DESCRIPTION
This pull request includes changes to the way the device token is outputted in various files. The most important changes involve modifying the output method to avoid adding a newline character.

Changes to device token output:

* [`scripts/get-device-token.ps1`](diffhunk://#diff-fd802531703bf635bc9fd4bd66723e1cef1bcffc90206e698afc15bb66fdfce8L28-R34): Changed the output method from `Write-Output` to `Write-Host -NoNewline` to avoid adding a newline character when displaying the device token.
* [`src-tauri/src/devicetoken_script.rs`](diffhunk://#diff-5a4d8cdb7cc827ac945286c57a9ff181c2edb5b42c3ba4446aa3a49621429530L32-R33): Updated the output method to `Write-Host -NoNewline` to ensure the device token is displayed without a newline character.
* [`src/components/Settings/Experimental/device-token-powershell-script.ts`](diffhunk://#diff-a9eb82b50956532ad6b4253cca17c0d81706e9b849af869e47a153fe700394ddL30-R31): Modified the output method to `Write-Host -NoNewline` to prevent a newline character from being added to the device token output.